### PR TITLE
Adds twitter stream to homepage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,5 @@ gem "minima", "~> 2.0"
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
    gem "jekyll-seo-tag"
+   gem 'jekyll-twitter-plugin'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.1.0)
       jekyll (~> 3.3)
+    jekyll-twitter-plugin (2.0.0)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kramdown (1.12.0)
@@ -49,10 +50,11 @@ DEPENDENCIES
   jekyll (= 3.3.0)
   jekyll-feed (~> 0.6)
   jekyll-seo-tag
+  jekyll-twitter-plugin
   minima (~> 2.0)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.0.0p648
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter:
   username: drupaldiversity
 twitter_username: drupaldiversity
+twitter_url: https://twitter.com/drupaldiversity
 github_username:  drupaldiversity
 logo: /assets/drupaldiversity_logo_300.png
 
@@ -39,6 +40,7 @@ theme: minima
 gems:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-twitter-plugin
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,10 +16,6 @@
             {% include icon-twitter.html username=site.twitter_username %}
           </li>
           {% endif %}
-
-          {% if site.twitter_username %}
-            {% twitter {{ site.twitter }} maxwidth=216 limit=5 %}
-          {% endif %}
         </ul>
       </div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,6 +16,10 @@
             {% include icon-twitter.html username=site.twitter_username %}
           </li>
           {% endif %}
+
+          {% if site.twitter_username %}
+            {% twitter {{ site.twitter }} maxwidth=216 limit=5 %}
+          {% endif %}
         </ul>
       </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,6 +26,10 @@ layout: default
 
   <div class="wrapper-col-2">
     <p>{{ site.description | escape }}</p>
+
+    {% if site.twitter_username %}
+    {% twitter https://twitter.com/drupaldiversity maxwidth=325 height=400 limit=2 hide_media=true %}
+    {% endif %}
   </div>
 
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -24,6 +24,17 @@
   float: left;
   margin: 10% 0;
 }
+.home {
+  .wrapper-col-1 {
+    width: -webkit-calc(50% - (#{$spacing-unit} / 2));
+    width:         calc(50% - (#{$spacing-unit} / 2));
+  }
+  .wrapper-col-2 {
+    width: -webkit-calc(50% - (#{$spacing-unit} / 2));
+    width:         calc(50% - (#{$spacing-unit} / 2));
+    margin: 0;
+  }
+}
 .footer-col-1 {
   width: -webkit-calc(33.334% - (#{$spacing-unit} / 2));
   width:         calc(33.334% - (#{$spacing-unit} / 2));


### PR DESCRIPTION
This PR adds the last two tweets to the homepage. The number is configurable, but more than two makes the page too scrolly, IMO. Here's a screenshot:

<img width="465" alt="screen shot 2017-05-06 at 8 08 36 am" src="https://cloud.githubusercontent.com/assets/199713/25772186/80e32c94-3233-11e7-942c-f098f54ecbf3.png">

I tried initially to put the URL in the _config.yml, but the jekyll-twitter-plugin doesn't seem to support that properly (or I can't figure it out - more likely). That could possibly be addressed in a subsequent PR unless anyone else can figure it out. ;)