### PR TITLE
#3038438: Create redirect from drupaldiversity.github.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,11 +35,15 @@ social:
     - https://github.com/drupaldiversity
     - https://twitter.com/drupaldiversity
 
+plugins:
+  - jekyll-redirect-from
+
 # Build settings
 markdown: kramdown
 theme: minima
 gems:
   - jekyll-feed
+  - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-twitter-plugin
 exclude:

--- a/_posts/2016-10-20-diversity-news.md
+++ b/_posts/2016-10-20-diversity-news.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Diversity in the news
+redirect_to: https://www.drupaldiversity.com/blog/2016/diversity-news
 date:   2016-10-20 11:03:52 -0700
 category: diversity-in-the-news
 author: drupaldiversity

--- a/_posts/2016-12-20-year-in-review.md
+++ b/_posts/2016-12-20-year-in-review.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "2016 in review"
+redirect_to: https://www.drupaldiversity.com/blog/2016/2016-year-review
 date:   2016-12-20 11:03:52 -0700
 author: drnikki
 ---

--- a/_posts/2017-03-30-drupalcon-baltimore-photobooth.md
+++ b/_posts/2017-03-30-drupalcon-baltimore-photobooth.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Drupalcon Baltimore Photo Booth
+redirect_to: https://www.drupaldiversity.com/blog/2017/drupalcon-baltimore-photo-booth
 date:   2017-03-29 11:03:52 -0700
 published: true
 category: drupalcon

--- a/_posts/2017-05-11-teams.md
+++ b/_posts/2017-05-11-teams.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: The Creation of Teams
+redirect_to: https://www.drupaldiversity.com/blog/2017/creation-teams
 date:   2017-05-11 11:03:52 -0700
 published: true
 author: drupaldiversity

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About
+redirect_to: https://www.drupaldiversity.com/about
 permalink: /about/
 ---
 

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: FAQ
+redirect_to: https://www.drupaldiversity.com/faq/
 permalink: /faq/
 ---
 

--- a/get-involved.md
+++ b/get-involved.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Initiatives & Get Involved
+redirect_to: https://www.drupaldiversity.com/get-involved
 permalink: /get-involved/
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,5 +3,6 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
+redirect_to: https://www.drupaldiversity.com/
 author: drupaldiveristy
 ---

--- a/resources.md
+++ b/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Resources
+redirect_to: https://www.drupaldiversity.com/resources
 permalink: /resources/
 ---
 
@@ -28,13 +29,13 @@ Decades of research by organizational scientists, psychologists, sociologists, e
 Researchers find software repository GitHub approved code written by women at a higher rate than code written by men, but only if the gender was not disclosed
 [Women considered better coders – but only if they hide their gender, The Guardian, by Julia Carrie Wong, 12 February 2016](https://www.theguardian.com/technology/2016/feb/12/women-considered-better-coders-hide-gender-github "Women considered better coders – but only if they hide their gender, The Guardian, by Julia Carrie Wong, 12 February 2016")
 
-* **How Diversity Can Drive Innovation** 
+* **How Diversity Can Drive Innovation**
 [How Diversity Can Drive Innovation, Harvard Business Review, by Sylvia Ann Hewlett, Melinda Marshall and Laura Sherbin, The December 2013 Issue](https://hbr.org/2013/12/how-diversity-can-drive-innovation "How Diversity Can Drive Innovation, Harvard Business Review, by Sylvia Ann Hewlett, Melinda Marshall and Laura Sherbin, The December 2013 Issue")
 
-* **Why Gender-Diverse Work Teams Are The Most Productive -- And Profitable** 
+* **Why Gender-Diverse Work Teams Are The Most Productive -- And Profitable**
 [Why Gender-Diverse Work Teams Are The Most Productive -- And Profitable, The Forbes, by Panos Mourdoukoutas, Dec 21 2016](http://www.forbes.com/sites/learnvest/2014/12/22/why-gender-diverse-work-teams-are-the-most-productive-and-profitable/ "Why Gender-Diverse Work Teams Are The Most Productive -- And Profitable, The Forbes, by Panos Mourdoukoutas, Dec 21 2016")
 
-* **Why diversity matters** 
+* **Why diversity matters**
 [Why diversity matters, McKinsey.com, by Vivian Hunt, 2015](http://www.mckinsey.com/business-functions/organization/our-insights/why-diversity-matters "Why diversity matters, McKinsey.com, by Vivian Hunt, 2015")
 
 * **We’re Making the Wrong Case for Diversity in Silicon Valley**
@@ -42,7 +43,7 @@ Researchers find software repository GitHub approved code written by women at a 
 
 ## Illustrating and talking about it
 
-* **Buffer Diversity Dashboard**: 
+* **Buffer Diversity Dashboard**:
 [Diversity Dashboard 2.0, Buffer](http://diversity.buffer.com "Diversity Dashboard 2.0, Buffer")
 
 * **Diversity and Inclusion: An update on our data | Slack**
@@ -71,7 +72,7 @@ Researchers find software repository GitHub approved code written by women at a 
 * **Racial Equity Tools**:
 [Racial Equity Tools](https://www.racialequitytools.org/home "Racial Equity Tools")
 
-* **Managing Unconscious Bias**: 
+* **Managing Unconscious Bias**:
 [Managing Unconscious Bias](https://managingbias.fb.com/ "Managing Unconscious Bias, Facebook")
 
 * **Social Justice Phrase Guide**:
@@ -82,5 +83,5 @@ Researchers find software repository GitHub approved code written by women at a 
 * **Books to Help You Understand Your Biases and the Lived Experiences of People**
 [The 101-Level Reader: Books to Help You Better Understand Your Biases and the Lived Experiences of People, Ashe Dryden (long list of resources)](https://www.ashedryden.com/blog/the-101level-reader-books-to-help-you-better-understand-your-biases-and-the-lived-experiences "The 101-Level Reader: Books to Help You Better Understand Your Biases and the Lived Experiences of People, Ashe Dryden (long list of resources)")
 
-* **Project Include**: 
+* **Project Include**:
 [Project Include](http://projectinclude.org "Project Include")


### PR DESCRIPTION
## Issue
https://www.drupal.org/project/ddi_contrib/issues/3038438

## Description
We need to make sure we adequately handle redirections from drupaldiversity.github.io to the new drupaldiversity.com website.

#### Page redirects:

- https://drupaldiversity.github.io/ to https://www.drupaldiversity.com/
- https://drupaldiversity.github.io/about/ to https://www.drupaldiversity.com/about
- https://drupaldiversity.github.io/get-involved/ to https://www.drupaldiversity.com/get-involved
- https://drupaldiversity.github.io/resources/ to https://www.drupaldiversity.com/resources
- https://drupaldiversity.github.io/faq/ to https://www.drupaldiversity.com/faq/

#### Blog post redirects:

- https://drupaldiversity.github.io/2017/05/11/teams.html to https://www.drupaldiversity.com/blog/2017/creation-teams
- https://drupaldiversity.github.io/diversity-in-the-news/2016/10/20/diver... to https://www.drupaldiversity.com/blog/2016/diversity-news
- https://drupaldiversity.github.io/2016/12/20/year-in-review.html to https://www.drupaldiversity.com/blog/2016/2016-year-review
- https://drupaldiversity.github.io/drupalcon/2017/03/29/drupalcon-baltimo... to https://www.drupaldiversity.com/blog/2017/drupalcon-baltimore-photo-booth